### PR TITLE
Issue 799 easessions close on disconnect

### DIFF
--- a/SmartDeviceLink/private/SDLIAPControlSession.h
+++ b/SmartDeviceLink/private/SDLIAPControlSession.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+
 #import "SDLIAPSession.h"
 
 @class EAAccessory;
@@ -27,13 +28,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Creates a new control session.
  *
- *  @param accessory    The accessory to connect to.
+ *  @param accessory      The accessory to connect to.
  *  @param delegate     The control session delegate
  *  @return             A SDLIAPControlSession object
  */
 - (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPControlSessionDelegate>)delegate forProtocol:(NSString *)protocol;
 
-// document
+/**
+ *  Closes the SDLIAPSession used by the SDLIAPControlSession
+ */
 - (void) closeSession;
 
 /**
@@ -42,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic, readonly, getter=isSessionInProgress) BOOL sessionInProgress;
 
 /**
- *  The accessory with which to open a session.
+ *  The accessory used to create and the EASession.
  */
 @property (nullable, strong, nonatomic, readonly) EAAccessory *accessory;
 
@@ -54,5 +57,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-

--- a/SmartDeviceLink/private/SDLIAPControlSession.h
+++ b/SmartDeviceLink/private/SDLIAPControlSession.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-
 #import "SDLIAPSession.h"
 
 @class EAAccessory;
@@ -21,19 +20,39 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  When the protocol string is received from Core, the control session is closed as a new session with Core must be established with the received protocol string. Core has ~10 seconds to send the protocol string, otherwise the control session is closed and new attempt is made to establish a control session with Core.
  */
-@interface SDLIAPControlSession : SDLIAPSession
+@interface SDLIAPControlSession: NSObject <SDLIAPSessionDelegate>
 
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
  *  Creates a new control session.
  *
- *  @param accessory      The accessory to connect to.
+ *  @param accessory    The accessory to connect to.
  *  @param delegate     The control session delegate
  *  @return             A SDLIAPControlSession object
  */
-- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPControlSessionDelegate>)delegate;
+- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPControlSessionDelegate>)delegate forProtocol:(NSString *)protocol;
+
+// document
+- (void) closeSession;
+
+/**
+ *  Returns whether the session has open I/O streams.
+ */
+@property (assign, nonatomic, readonly, getter=isSessionInProgress) BOOL sessionInProgress;
+
+/**
+ *  The accessory with which to open a session.
+ */
+@property (nullable, strong, nonatomic, readonly) EAAccessory *accessory;
+
+/**
+ *  The unique ID assigned to the session between the app and accessory. If no session exists the value will be 0.
+ */
+@property (assign, nonatomic, readonly) NSUInteger connectionID;
 
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLink/private/SDLIAPControlSession.m
+++ b/SmartDeviceLink/private/SDLIAPControlSession.m
@@ -22,206 +22,94 @@ NS_ASSUME_NONNULL_BEGIN
 int const ProtocolIndexTimeoutSeconds = 10;
 
 @interface SDLIAPControlSession ()
-
 @property (nullable, strong, nonatomic) SDLTimer *protocolIndexTimer;
 @property (weak, nonatomic) id<SDLIAPControlSessionDelegate> delegate;
-
+@property (nullable, nonatomic, strong) SDLIAPSession *iapSession;
 @end
 
 @implementation SDLIAPControlSession
 
 #pragma mark - Session lifecycle
 
-- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPControlSessionDelegate>)delegate {
-    SDLLogV(@"SDLIAPControlSession init");
-
-    self = [super initWithAccessory:accessory forProtocol:ControlProtocolString];
-    if (!self) { return nil; }
-
+- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPControlSessionDelegate>)delegate forProtocol:(NSString *)protocol {
+    SDLLogD(@"SDLIAPControlSession init with protocol %@ and accessory %@", protocol, accessory);
+    self = [super init];
+    _iapSession = [[SDLIAPSession alloc] initWithAccessory:accessory forProtocol:protocol iAPSessionDelegate:self];
     _protocolIndexTimer = nil;
     _delegate = delegate;
+    SDLLogD(@"SDLIAPControlSession Wait for the protocol string from Core, setting timeout timer for %d seconds", ProtocolIndexTimeoutSeconds);
+    self.protocolIndexTimer = [self sdl_createControlSessionProtocolIndexStringDataTimeoutTimer];
 
     return self;
 }
 
-#pragma mark Start
-
-- (void)startSession {
-    if (self.accessory == nil) {
-        SDLLogW(@"There is no control session in progress, attempting to create a new control session.");
-        [self.delegate controlSessionShouldRetry];
-    } else {
-        SDLLogD(@"Starting a control session with accessory (%@)", self.accessory.name);
-        __weak typeof(self) weakSelf = self;
-        [self sdl_startStreamsWithCompletionHandler:^(BOOL success) {
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            if (!success) {
-                SDLLogW(@"Control session failed to setup with accessory: %@. Attempting to create a new control session", strongSelf.accessory);
-                [strongSelf destroySessionWithCompletionHandler:^{
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf.delegate controlSessionShouldRetry];
-                }];
-            } else {
-                SDLLogD(@"Waiting for the protocol string from Core, setting timeout timer for %d seconds", ProtocolIndexTimeoutSeconds);
-                strongSelf.protocolIndexTimer = [strongSelf sdl_createControlSessionProtocolIndexStringDataTimeoutTimer];
-            }
-        }];
-    }
+- (void) closeSession {
+    [self.iapSession closeSession];
 }
 
-/// Opens the input and output streams for the session on the main thread.
-/// @discussion We must close the input/output streams from the same thread that owns the streams' run loop, otherwise if the streams are closed from another thread a random crash may occur. Since only a small amount of data will be transmitted on this stream before it is closed, we will open and close the streams on the main thread instead of creating a separate thread.
-- (void)sdl_startStreamsWithCompletionHandler:(void (^)(BOOL success))completionHandler {
-    if (![super createSession]) {
-        return completionHandler(NO);
-    }
-
-    __weak typeof(self) weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-
-        SDLLogD(@"Created the control session successfully");
-        [super startStream:strongSelf.eaSession.outputStream];
-        [super startStream:strongSelf.eaSession.inputStream];
-
-        return completionHandler(YES);
-    });
+- (nullable EAAccessory *) accessory {
+    return self.iapSession.accessory;
+}
+- (NSUInteger)connectionID {
+    return self.iapSession.connectionID;
 }
 
-#pragma mark Stop
-
-/// Makes sure the session is closed and destroyed on the main thread.
-/// @param disconnectCompletionHandler Handler called when the session has disconnected
-- (void)destroySessionWithCompletionHandler:(void (^)(void))disconnectCompletionHandler {
-    SDLLogD(@"Destroying the control session");
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self sdl_stopAndDestroySession];
-        return disconnectCompletionHandler();
-    });
+- (BOOL)isSessionInProgress {
+    return [self.iapSession isSessionInProgress];
 }
-
-/// Closes the session streams and then destroys the session.
-- (void)sdl_stopAndDestroySession {
-    NSAssert(NSThread.isMainThread, @"%@ must only be called on the main thread", NSStringFromSelector(_cmd));
-
-    [super stopStream:self.eaSession.outputStream];
-    [super stopStream:self.eaSession.inputStream];
-    [super cleanupClosedSession];
-}
-
 
 #pragma mark - NSStreamDelegate
 
-/**
- *  Handles events on the input/output streams of the open session.
- *
- *  @param stream       The stream (either input or output) that the event occured on
- *  @param eventCode    The stream event code
- */
-- (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)eventCode {
-    switch (eventCode) {
-        case NSStreamEventOpenCompleted: {
-            [self sdl_streamDidOpen:stream];
-            break;
-        }
-        case NSStreamEventHasBytesAvailable: {
-            [self sdl_streamHasBytesAvailable:(NSInputStream *)stream];
-            break;
-        }
-        case NSStreamEventErrorOccurred: {
-            [self sdl_streamDidError:stream];
-            break;
-        }
-        case NSStreamEventEndEncountered: {
-            [self sdl_streamDidEnd:stream];
-            break;
-        }
-        case NSStreamEventNone:
-        case NSStreamEventHasSpaceAvailable:
-        default: {
-            break;
-        }
-    }
-}
 
-/**
- *  Called when the session gets a `NSStreamEventOpenCompleted`. When both the input and output streams open, start a timer to get data from Core within a certain timeframe.
- *
- *  @param stream The stream that got the event code.
- */
-- (void)sdl_streamDidOpen:(NSStream *)stream {
-    if (stream == [self.eaSession outputStream]) {
-        SDLLogD(@"Control session output stream opened");
-        self.isOutputStreamOpen = YES;
-    } else if (stream == [self.eaSession inputStream]) {
-        SDLLogD(@"Control session input stream opened");
-        self.isInputStreamOpen = YES;
-    }
-
-    // When both streams are open, session initialization is complete. Let the delegate know.
-    if (self.isInputStreamOpen && self.isOutputStreamOpen) {
-        SDLLogV(@"Control session I/O streams opened for protocol: %@", self.protocolString);
+- (void) streamsDidOpen {
+    SDLLogD(@"SDLIAPControlSession streams opened for control session instance %@", self);
+    if (self.delegate != nil) {
         [self sdl_startControlSessionProtocolIndexStringDataTimeoutTimer];
     }
 }
 
-/**
- *  Called when the session gets a `NSStreamEventEndEncountered` event code. The current session is closed and a new session is attempted.
- */
-- (void)sdl_streamDidEnd:(NSStream *)stream {
-    SDLLogD(@"Control stream ended");
-
-    // End events come in pairs, only perform this once per set.
-    [self.protocolIndexTimer cancel];
-
-    __weak typeof(self) weakSelf = self;
-    [self destroySessionWithCompletionHandler:^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf.delegate controlSessionShouldRetry];
-    }];
+- (void) streamsDidEnd {
+    SDLLogD(@"SDLIAPControlSession EASession stream ended");
+    if (self.delegate != nil) {
+        [self.delegate controlSessionDidEnd];
+    }
 }
+
+- (void)streamHasSpaceToWrite {}
 
 /**
  *  Called when the session gets a `NSStreamEventHasBytesAvailable` event code. A protocol string is created from the received data. Since a new session needs to be established with the protocol string, the current session is closed and a new session is created.
  */
-- (void)sdl_streamHasBytesAvailable:(NSInputStream *)inputStream {
-    SDLLogV(@"Control stream received data");
-
+- (void)streamHasBytesAvailable:(NSInputStream *)inputStream {
+    SDLLogD(@"SDLIAPControlSession EASession stream received data");
+    
     // Read in the stream a single byte at a time
     uint8_t buf[1];
     NSInteger len = [inputStream read:buf maxLength:1];
     if (len <= 0) {
-        SDLLogV(@"No data in the control stream");
+        SDLLogD(@"No data in the control stream");
         return;
     }
-
-    // If we have data from the control stream, use the data to create the protocol string needed to establish the data session.
+    
+    // If we have data from the control stream, use the data to create the protocol string needed to establish a data session.
     NSString *indexedProtocolString = [NSString stringWithFormat:@"%@%@", IndexedProtocolStringPrefix, @(buf[0])];
-    SDLLogD(@"Control Stream will switch to protocol %@", indexedProtocolString);
-
-    // Destroy the control session as it is no longer needed, and then create the data session.
-    __weak typeof(self) weakSelf = self;
-    [self destroySessionWithCompletionHandler:^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (strongSelf.accessory.isConnected) {
-            [strongSelf.protocolIndexTimer cancel];
-            [strongSelf.delegate controlSession:strongSelf didReceiveProtocolString:indexedProtocolString];
-        }
-    }];
+    SDLLogD(@"SDLIAPControlSession EASession Stream will switch to protocol %@", indexedProtocolString);
+    
+    [self.protocolIndexTimer cancel];
+    if (self.delegate != nil) {
+        [self.delegate controlSession:self didReceiveProtocolString:indexedProtocolString];
+    }
 }
 
 /**
  *  Called when the session gets a `NSStreamEventErrorOccurred` event code. The current session is closed and a new session is attempted.
  */
-- (void)sdl_streamDidError:(NSStream *)stream {
-    SDLLogE(@"Control stream error");
-
+- (void)streamDidError {
+    SDLLogE(@"SDLIAPControlSession stream error");
     [self.protocolIndexTimer cancel];
-    __weak typeof(self) weakSelf = self;
-    [self destroySessionWithCompletionHandler:^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf.delegate controlSessionShouldRetry];
-    }];
+    if (self.delegate != nil) {
+        [self.delegate controlSessionDidEnd];
+    }
 }
 
 #pragma mark - Timer
@@ -233,17 +121,14 @@ int const ProtocolIndexTimeoutSeconds = 10;
  */
 - (SDLTimer *)sdl_createControlSessionProtocolIndexStringDataTimeoutTimer {
     SDLTimer *protocolIndexTimer = [[SDLTimer alloc] initWithDuration:ProtocolIndexTimeoutSeconds repeat:NO];
-
     __weak typeof(self) weakSelf = self;
     void (^elapsedBlock)(void) = ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        SDLLogW(@"Control session failed to get the protocol string from Core after %d seconds, retrying.", ProtocolIndexTimeoutSeconds);
-        [strongSelf destroySessionWithCompletionHandler:^{
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            [strongSelf.delegate controlSessionShouldRetry];
-        }];
+        SDLLogW(@"SDLIAPControlSession failed to get the protocol string from Core after %d seconds, retrying.", ProtocolIndexTimeoutSeconds);
+        if (self.delegate != nil) {
+            [strongSelf.delegate controlSessionDidEnd];
+        }
     };
-
     protocolIndexTimer.elapsedBlock = elapsedBlock;
     return protocolIndexTimer;
 }
@@ -259,3 +144,5 @@ int const ProtocolIndexTimeoutSeconds = 10;
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLink/private/SDLIAPControlSessionDelegate.h
+++ b/SmartDeviceLink/private/SDLIAPControlSessionDelegate.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SDLIAPControlSessionDelegate <NSObject>
 
-- (void)controlSessionShouldRetry;
+- (void)controlSessionDidEnd;
 - (void)controlSession:(SDLIAPControlSession *)controlSession didReceiveProtocolString:(NSString *)protocolString;
 
 @end

--- a/SmartDeviceLink/private/SDLIAPDataSession.h
+++ b/SmartDeviceLink/private/SDLIAPDataSession.h
@@ -43,17 +43,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPDataSessionDelegate>)delegate forProtocol:(NSString *)protocol;
 
 /**
+ *  Closes the SDLIAPSession used by the SDLIAPControlSession
+ */
+- (void) closeSession;
+
+/**
  *  Sends data to Core via the data session.
  *
  *  @param data The data to send to Core
  */
 - (void)sendData:(NSData *)data;
 
-// document
-- (void) closeSession;
-
 @end
 
 NS_ASSUME_NONNULL_END
-
 

--- a/SmartDeviceLink/private/SDLIAPDataSession.h
+++ b/SmartDeviceLink/private/SDLIAPDataSession.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-
 #import "SDLIAPSession.h"
 
 @protocol SDLIAPDataSessionDelegate;
@@ -15,10 +14,25 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SDLIAPDataSession : SDLIAPSession
+@interface SDLIAPDataSession: NSObject <SDLIAPSessionDelegate>
 
 - (instancetype)init NS_UNAVAILABLE;
 
+
+/**
+ *  Returns whether the session has open I/O streams.
+ */
+@property (assign, nonatomic, readonly, getter=isSessionInProgress) BOOL sessionInProgress;
+
+/**
+ *  The unique ID assigned to the session between the app and accessory. If no session exists the value will be 0.
+ */
+@property (assign, nonatomic, readonly) NSUInteger connectionID;
+
+/**
+ *  The accessory with which to open a session.
+ */
+@property (nullable, strong, nonatomic, readonly) EAAccessory *accessory;
 /**
  *  Creates a new data session.
  *
@@ -35,6 +49,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)sendData:(NSData *)data;
 
+// document
+- (void) closeSession;
+
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLink/private/SDLIAPDataSession.m
+++ b/SmartDeviceLink/private/SDLIAPDataSession.m
@@ -6,28 +6,23 @@
 //  Copyright © 2019 smartdevicelink. All rights reserved.
 //
 
+#import <UIKit/UIDevice.h>
 #import "SDLIAPDataSession.h"
-
 #import "SDLGlobals.h"
 #import "SDLIAPConstants.h"
 #import "SDLIAPDataSessionDelegate.h"
 #import "SDLIAPSession.h"
 #import "SDLLogMacros.h"
 #import "SDLMutableDataQueue.h"
-
-NSString *const IOStreamThreadName = @"com.smartdevicelink.iostream";
-NSTimeInterval const IOStreamThreadCanceledSemaphoreWaitSecs = 1.0;
+#import "SDLLifecycleManager.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLIAPDataSession ()
 
-@property (nullable, nonatomic, strong) NSThread *ioStreamThread;
-@property (nonatomic, strong) SDLMutableDataQueue *sendDataQueue;
+@property (nullable, nonatomic, strong) SDLIAPSession *iapSession;
 @property (weak, nonatomic) id<SDLIAPDataSessionDelegate> delegate;
-/// A semaphore used to block the current thread until we know that the I/O streams have been shutdown on the ioStreamThread
-@property (nonatomic, strong) dispatch_semaphore_t ioStreamThreadCancelledSemaphore;
-
+@property (nullable, nonatomic, strong) SDLMutableDataQueue *sendDataQueue;
 @end
 
 @implementation SDLIAPDataSession
@@ -35,341 +30,120 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Lifecycle
 
 - (instancetype)initWithAccessory:(nullable EAAccessory *)accessory delegate:(id<SDLIAPDataSessionDelegate>)delegate forProtocol:(NSString *)protocol; {
-    SDLLogV(@"iAP data session init for accessory: %@", accessory);
-
-    self = [super initWithAccessory:accessory forProtocol:protocol];
-    if (!self) { return nil; }
-
+    SDLLogD(@"SDLIAPDataSession iAP data session init for accessory: %@", accessory);
+    self = [super init];
     _delegate = delegate;
+    _iapSession = [[SDLIAPSession alloc] initWithAccessory:accessory forProtocol:protocol iAPSessionDelegate:self];
     _sendDataQueue = [[SDLMutableDataQueue alloc] init];
-    _ioStreamThreadCancelledSemaphore = dispatch_semaphore_create(0);
-
     return self;
 }
 
+- (void) closeSession {
+    [self.iapSession closeSession];
+}
 
-#pragma mark Start
+- (void)sendData:(NSData *)data {
+    [self.sendDataQueue enqueueBuffer:data.mutableCopy];
+    if (!self.iapSession.hasSpaceAvailable) {
+        SDLLogD(@"SDLIAPDataSession needs to send data but no space available on IAPSession %@.", self.iapSession);
+        return;
+    }
+    [self writeDataToSessionStream];
+}
 
-- (void)startSession {
-    if (self.accessory == nil) {
-        SDLLogW(@"Failed to setup data session");
-        if (self.delegate == nil) { return; }
-        [self.delegate dataSessionShouldRetry];
+- (void) writeDataToSessionStream {
+    NSMutableData *remainder = [self.sendDataQueue frontBuffer];
+    if (remainder != nil) {
+        NSUInteger bytesRemaining = remainder.length;
+  //      SDLLogD(@"SDLIAPDataSession sending data for IAPSession %@.", self.iapSession);
+        [self.iapSession write:remainder length:bytesRemaining withCompletionHandler:^(NSInteger bytesWritten) {
+            if (bytesWritten == bytesRemaining) {
+                [self.sendDataQueue popBuffer];
+            } else {
+                // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
+                // SDLLogD(@"SDLIAPDataSession writeDataToSessionStream bytes written %ld", (long)bytesWritten);
+                [remainder replaceBytesInRange:NSMakeRange(0, (NSUInteger)bytesWritten) withBytes:NULL length:0];
+            }
+        }];
     } else {
-        SDLLogD(@"Starting data session with accessory: %@, using protocol: %@", self.accessory.name, self.protocolString);
-
-        if (![super createSession]) {
-            SDLLogW(@"Data session failed to setup with accessory: %@. Retrying...", self.accessory);
-            __weak typeof(self) weakSelf = self;
-            [self destroySessionWithCompletionHandler:^{
-                __strong typeof(weakSelf) strongSelf = weakSelf;
-                if (strongSelf.delegate == nil) { return; }
-                [strongSelf.delegate dataSessionShouldRetry];
-            }];
-        }
-
-        if (self.eaSession != nil) {
-            self.ioStreamThread = [[NSThread alloc] initWithTarget:self selector:@selector(sdl_accessoryEventLoop) object:nil];
-            [self.ioStreamThread setName:IOStreamThreadName];
-            [self.ioStreamThread start];
-        }
+        SDLLogD(@"No more data to write to data session's output stream for IAPSession %@", self.iapSession);
+        return;
     }
 }
-
-#pragma mark Stop
-
-/// Waits for the ioStreamThread to close and destroy the I/O streams.
-/// @param disconnectCompletionHandler Handler called when the session has disconnected
-- (void)destroySessionWithCompletionHandler:(void (^)(void))disconnectCompletionHandler {
-    SDLLogD(@"Destroying the data session");
-
-    if (self.ioStreamThread == nil) {
-        SDLLogV(@"No data session established");
-        [super cleanupClosedSession];
-        return disconnectCompletionHandler();
-    }
-
-    // Tell the ioStreamThread to shutdown the I/O streams. The I/O streams must be opened and closed on the same thread; if they are not, random crashes can occur. Dispatch this task to the main queue to ensure that this task is performed on the Main Thread. We are using the Main Thread for ease since we don't want to create a separate thread just to wait on closing the I/O streams. Using the Main Thread ensures that semaphore wait is not called from ioStreamThread, which would block the ioStreamThread and prevent shutdown.
-    __weak typeof(self) weakSelf = self;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-
-        // Attempt to cancel the ioStreamThread. Once the thread realizes it has been cancelled, it will cleanup the I/O streams. Make sure to wake up the run loop in case there is no current I/O event running on the ioThread.
-        [strongSelf.ioStreamThread cancel];
-        [strongSelf performSelector:@selector(sdl_doNothing) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
-
-        // Block the thread until the semaphore has been released by the ioStreamThread (or a timeout has occured).
-        BOOL cancelledSuccessfully = [strongSelf sdl_isIOThreadCancelled];
-        if (!cancelledSuccessfully) {
-            SDLLogE(@"The I/O streams were not shut down successfully. We might not be able to create a new session with an accessory during the same app session. If this happens, only force quitting and restarting the app will allow new sessions.");
-        }
-
-        [strongSelf.sendDataQueue removeAllObjects];
-
-        disconnectCompletionHandler();
-    });
-}
-
-/// Wait for the ioStreamThread to destroy the I/O streams. Make sure this method is not called on the ioStreamThread, as it will block the thread until the timeout occurs.
-/// @return Whether or not the session's I/O streams were closed successfully.
-- (BOOL)sdl_isIOThreadCancelled {
-    NSAssert(![NSThread.currentThread.name isEqualToString:IOStreamThreadName], @"%@ must not be called from the ioStreamThread!", NSStringFromSelector(_cmd));
-
-    long lWait = dispatch_semaphore_wait(self.ioStreamThreadCancelledSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(IOStreamThreadCanceledSemaphoreWaitSecs * NSEC_PER_SEC)));
-    if (lWait == 0) {
-        SDLLogD(@"ioStreamThread cancelled successfully");
-        return YES;
-    }
-
-    SDLLogE(@"Failed to cancel ioStreamThread within %.1f seconds", IOStreamThreadCanceledSemaphoreWaitSecs);
-    return NO;
-}
-
-/// Helper method for waking up the ioStreamThread.
-- (void)sdl_doNothing {}
 
 #pragma mark - Sending data
 
-- (void)sendData:(NSData *)data {
-    // Enqueue the data for transmission on the IO thread
-    [self.sendDataQueue enqueueBuffer:data.mutableCopy];
-
-    [self performSelector:@selector(sdl_dequeueAndWriteToOutputStream) onThread:self.ioStreamThread withObject:nil waitUntilDone:NO];
-}
-
-/**
- *  Sends any queued data to Core on the output stream for the session.
- */
-- (void)sdl_dequeueAndWriteToOutputStream {
-    if ([self.ioStreamThread isCancelled]) {
-        SDLLogW(@"Attempted to send data on I/O thread but the thread is cancelled.");
-        return;
-    }
-
-    NSOutputStream *ostream = self.eaSession.outputStream;
-    if (!ostream.hasSpaceAvailable) {
-        SDLLogV(@"Attempted to send data with output stream but there is no space available.");
-        return;
-    }
-
-    NSMutableData *remainder = [self.sendDataQueue frontBuffer];
-    if (remainder == nil) {
-        SDLLogV(@"No more data to write to data session's output stream. Returning");
-        return;
-    }
-
-    NSUInteger bytesRemaining = remainder.length;
-    NSInteger bytesWritten = [ostream write:remainder.bytes maxLength:bytesRemaining];
-
-    if (bytesWritten < 0) {
-        if (ostream.streamError != nil) {
-            // Once a stream has reported an error, it cannot be re-used for read or write operations. Shut down the stream and attempt to create a new session.
-            [self sdl_streamDidError:ostream];
-        } else {
-            // The write operation failed but there is no further information about the error. This can occur when disconnecting from an external accessory.
-            SDLLogE(@"Output stream write operation failed");
-        }
-    } else if (bytesWritten == bytesRemaining) {
-        // Remove the data from the queue
-        [self.sendDataQueue popBuffer];
-    } else {
-        // Cleave the sent bytes from the data, the remainder will sit at the head of the queue
-        [remainder replaceBytesInRange:NSMakeRange(0, (NSUInteger)bytesWritten) withBytes:NULL length:0];
-    }
-}
-
 #pragma mark - NSStreamDelegate
 
-/**
- *  Handles events on the input/output streams of the open session.
- *
- *  @param stream       The stream (either input or output) that the event occured on
- *  @param eventCode    The stream event code
- */
-- (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)eventCode {
-    switch (eventCode) {
-        case NSStreamEventOpenCompleted: {
-            [self sdl_streamDidOpen:stream];
-            break;
-        }
-        case NSStreamEventHasBytesAvailable: {
-            [self sdl_streamHasBytesAvailable:(NSInputStream *)stream];
-            break;
-        }
-        case NSStreamEventHasSpaceAvailable: {
-            [self sdl_streamHasSpaceToWrite];
-            break;
-        }
-        case NSStreamEventErrorOccurred: {
-            [self sdl_streamDidError:stream];
-            break;
-        }
-        case NSStreamEventEndEncountered: {
-            [self sdl_streamDidEnd:stream];
-            break;
-        }
-        case NSStreamEventNone:
-        default: {
-            break;
-        }
-    }
-}
-
-/**
- *  Called when the session gets a `NSStreamEventOpenCompleted`. When both the input and output streams open, notify the lifecycle manager that a connection has been established with the accessory.
- *
- *  @param stream The stream that got the event code.
- */
-- (void)sdl_streamDidOpen:(NSStream *)stream {
-    if (stream == [self.eaSession outputStream]) {
-        SDLLogD(@"Data session output stream opened");
-        self.isOutputStreamOpen = YES;
-    } else if (stream == [self.eaSession inputStream]) {
-        SDLLogD(@"Data session input stream opened");
-        self.isInputStreamOpen = YES;
-    }
-
-    // When both streams are open, session initialization is complete. Let the delegate know.
-    if (self.isInputStreamOpen && self.isOutputStreamOpen) {
-        SDLLogV(@"Data session I/O streams opened for protocol: %@", self.protocolString);
-        if (self.delegate == nil) { return; }
+- (void) streamsDidOpen {
+    SDLLogD(@"SDLIAPDataSession streams opened for data session instance %@", self);
+    if (self.delegate != nil) {
         [self.delegate dataSessionDidConnect];
     }
 }
 
-/**
- *  Called when the session gets a `NSStreamEventEndEncountered` event code. The current session is closed and a new session is attempted.
- */
-- (void)sdl_streamDidEnd:(NSStream *)stream {
-    NSAssert(!NSThread.isMainThread, @"%@ should only be called on the IO thread", NSStringFromSelector(_cmd));
-
-    SDLLogD(@"Data stream ended");
-    if (self.accessory == nil) {
-        SDLLogD(@"Data session is nil");
-        return;
-    }
-
-    // The handler will be called on the I/O thread, but the session stop method must be called on the main thread
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __weak typeof(self) weakSelf = self;
-        [self destroySessionWithCompletionHandler:^{
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            if (strongSelf.delegate == nil) { return; }
-            [strongSelf.delegate dataSessionShouldRetry];
-        }];
-    });
-
-    // To prevent deadlocks the handler must return to the runloop and not block the thread
+- (void) streamHasSpaceToWrite {
+    [self writeDataToSessionStream];
 }
 
-/**
- *  Called when the session gets a `NSStreamEventHasBytesAvailable` event code. The data is passed to the listener.
- */
-- (void)sdl_streamHasBytesAvailable:(NSInputStream *)inputStream {
-    NSAssert(!NSThread.isMainThread, @"%@ should only be called on the IO thread", NSStringFromSelector(_cmd));
+- (void) streamHasBytesAvailable:(NSInputStream *)inputStream {
     uint8_t buf[[[SDLGlobals sharedGlobals] mtuSizeForServiceType:SDLServiceTypeRPC]];
+    // It is necessary to check the stream status and whether there are bytes available
+    // because the dataStreamHasBytesHandler is executed on the IO thread and
+    // the accessory disconnect notification arrives on the main thread, causing data to be passed to the delegate
+    // if the main thread is tearing down the transport.
     while (inputStream.streamStatus == NSStreamStatusOpen && inputStream.hasBytesAvailable) {
-        // It is necessary to check the stream status and whether there are bytes available because the dataStreamHasBytesHandler is executed on the IO thread and the accessory disconnect notification arrives on the main thread, causing data to be passed to the delegate while the main thread is tearing down the transport.
         NSInteger bytesRead = [inputStream read:buf maxLength:[[SDLGlobals sharedGlobals] mtuSizeForServiceType:SDLServiceTypeRPC]];
         if (bytesRead < 0) {
-            SDLLogE(@"Failed to read from data stream");
+            SDLLogE(@"Failed to read from EASession data stream %@", inputStream);
             break;
         }
-
         NSData *dataIn = [NSData dataWithBytes:buf length:(NSUInteger)bytesRead];
         SDLLogBytes(dataIn, SDLLogBytesDirectionReceive);
 
         if (bytesRead > 0) {
-            if (self.delegate == nil) { return; }
-            [self.delegate dataSessionDidReceiveData:dataIn];
+            if (self.delegate != nil) {
+                [self.delegate dataSessionDidReceiveData:dataIn];
+            }
         } else {
             break;
         }
     }
 }
 
-/**
- *  Called when the session gets a `NSStreamEventHasSpaceAvailable` event code. Send any queued data to Core.
- */
-- (void)sdl_streamHasSpaceToWrite {
-    [self sdl_dequeueAndWriteToOutputStream];
-}
-
-/**
- *  Called when the session gets a `NSStreamEventErrorOccurred` event code. The current session is closed and a new session is attempted.
- */
-- (void)sdl_streamDidError:(NSStream *)stream {
-    NSAssert(!NSThread.isMainThread, @"%@ should only be called on the IO thread", NSStringFromSelector(_cmd));
-
-    SDLLogE(@"Data session %s stream errored", stream == self.eaSession.inputStream ? "input" : "output");
-
-    // To prevent deadlocks the handler must return to the runloop and not block the thread
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __weak typeof(self) weakSelf = self;
-        [self destroySessionWithCompletionHandler:^{
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            if (![strongSelf.protocolString isEqualToString:LegacyProtocolString]) {
-                if (strongSelf.delegate == nil) { return; }
-                [strongSelf.delegate dataSessionShouldRetry];
-            }
-        }];
-    });
-}
-
-#pragma mark - Stream lifecycle
-
-// Data session I/O thread
-- (void)sdl_accessoryEventLoop {
-    @autoreleasepool {
-        NSAssert(self.eaSession != nil, @"Session must be assigned before calling");
-        if (!self.eaSession) {
-            return;
-        }
-
-        [self startStream:self.eaSession.inputStream];
-        [self startStream:self.eaSession.outputStream];
-
-        SDLLogD(@"Starting the accessory event loop on thread: %@", NSThread.currentThread.name);
-
-        while (self.ioStreamThread != nil && !self.ioStreamThread.cancelled) {
-            // Enqueued data will be written to and read from the streams in the runloop
-            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
-        }
-
-        SDLLogD(@"Closing the accessory event loop on thread: %@", NSThread.currentThread.name);
-
-        // Close I/O streams
-        [self sdl_closeSession];
-        [super cleanupClosedSession];
-
-        // If a thread is blocked waiting on the I/O streams to shutdown, let the thread know that shutdown has completed.
-        dispatch_semaphore_signal(self.ioStreamThreadCancelledSemaphore);
+- (void) streamsDidEnd {
+    SDLLogD(@"SDLIAPDataSession EASession streamsDidEnd");
+    if (self.delegate != nil) {
+        [self.delegate  dataSessionDidEnd];
     }
 }
 
-// Must be called on accessoryEventLoop.
-- (void)sdl_closeSession {
-    if (self.eaSession == nil) {
-        return;
+- (void) streamDidError {
+    SDLLogD(@"SDLIAPDataSession EASession streamDidError");
+    if (![self.iapSession.protocolString isEqualToString:LegacyProtocolString]) {
+        [self.sendDataQueue removeAllObjects];
+        if (self.delegate != nil) {
+            [self.delegate  dataSessionDidEnd];
+        }
     }
-
-    SDLLogD(@"Closing EASession for accessory connection id: %tu, name: %@", self.connectionID, self.eaSession.accessory.name);
-
-    [self stopStream:[self.eaSession inputStream]];
-    [self stopStream:[self.eaSession outputStream]];
 }
 
-- (void)startStream:(NSStream *)stream {
-    NSAssert([[NSThread currentThread] isEqual:self.ioStreamThread] || [NSThread isMainThread], @"startStream is being called on the wrong thread!!!");
-    [super startStream:stream];
+#pragma mark Otherd
+
+- (nullable EAAccessory *) accessory {
+    return self.iapSession.accessory;
 }
 
-- (void)stopStream:(NSStream *)stream {
-    NSAssert([[NSThread currentThread] isEqual:self.ioStreamThread] || [NSThread isMainThread], @"stopStream is being called on the wrong thread!!!");
-    [super stopStream:stream];
+- (NSUInteger)connectionID {
+    return self.iapSession.connectionID;
 }
 
+- (BOOL)isSessionInProgress {
+    return [self.iapSession isSessionInProgress];
+}
 
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLink/private/SDLIAPDataSessionDelegate.h
+++ b/SmartDeviceLink/private/SDLIAPDataSessionDelegate.h
@@ -12,10 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SDLIAPDataSessionDelegate <NSObject>
 
-- (void)dataSessionShouldRetry;
+- (void)dataSessionDidEnd;
 - (void)dataSessionDidReceiveData:(NSData *)data;
 - (void)dataSessionDidConnect;
 
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/SmartDeviceLink/private/SDLIAPSession.h
+++ b/SmartDeviceLink/private/SDLIAPSession.h
@@ -28,21 +28,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithAccessory:(nullable EAAccessory *)accessory forProtocol:(NSString *)protocol iAPSessionDelegate:(id<SDLIAPSessionDelegate>)iAPSessionDelegate;
 
-// document
-- (void) closeSession;
-
-// document
-- (void)write:(NSMutableData *) data length: (NSUInteger) length  withCompletionHandler:(void (^)(NSInteger bytesWritten))completionHandler;
-
 /**
- *  The accessory with which to open a session.  Should be refactored to remove need to  make this public
+ *  The accessory that was used when creating a SLDLIAPSession instance.
  */
 @property (nullable, strong, nonatomic, readonly) EAAccessory *accessory;
 
 /**
- *  The unique protocol string used to create the session with the accessory.
+ *  @returns True if both inputStream and outputStream are open
  */
-@property (nullable, strong, nonatomic, readonly) NSString *protocolString;
+@property(readonly) BOOL bothStreamsOpen;
+
+/**
+ *  Closes the EASession inputStream and the outputStream.
+ *  Sets bothStreamsOpen flag to false.
+ *  Stops SDLIAPSesssion operation by removing streams from the run loop
+ *  By design a SDLIAPSession instance cannot be reopened.
+ */
+- (void) closeSession;
 
 /**
  *  The unique ID assigned to the session between the app and accessory. If no session exists the value will be 0.
@@ -50,18 +52,34 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic, readonly) NSUInteger connectionID;
 
 /**
- *  Returns whether the session has open I/O streams.
+ *  @returns True if the outputStream has space available to write data
+ */
+@property(readonly) BOOL hasSpaceAvailable;
+
+/**
+ *  @returns True if the sessions EAAccessory is connected
+ */
+@property(readonly) BOOL isConnected;
+
+/**
+ *  @returns True if either the inputStream or the outputStream is open
  */
 @property (assign, nonatomic, readonly, getter=isSessionInProgress) BOOL sessionInProgress;
 
-// document
-@property(readonly) BOOL hasSpaceAvailable;
-@property(readonly) BOOL bothStreamsOpen;
-@property(readonly) BOOL isConnected;
+/**
+ *  The unique protocol string used to create the session with the accessory.
+ */
+@property (nullable, strong, nonatomic, readonly) NSString *protocolString;
 
+/**
+ *
+ *  @param data  The data written to the EASession outputStream
+ *  @param length The number of data bytes to write
+ *  @param completionHandler  The number of data bytes actually written
+ */
+- (void)write:(NSMutableData *) data length: (NSUInteger) length  withCompletionHandler:(void (^)(NSInteger bytesWritten))completionHandler;
 
 @end
 
 NS_ASSUME_NONNULL_END
-
 

--- a/SmartDeviceLink/private/SDLIAPSession.h
+++ b/SmartDeviceLink/private/SDLIAPSession.h
@@ -8,38 +8,41 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol SDLIAPSessionDelegate <NSObject>
 
+- (void)streamsDidOpen;
+- (void)streamsDidEnd;
+- (void)streamHasSpaceToWrite;
+- (void)streamDidError;
+- (void)streamHasBytesAvailable:(NSInputStream *)inputStream;
+
+@end
 @interface SDLIAPSession : NSObject <NSStreamDelegate>
 
 /**
- *  The accessory with which to open a session.
+ *  Convenience initializer for setting an accessory and protocol string.
+ *
+ *  @param accessory    The accessory with which to open a session
+ *  @param protocol     The unique protocol string used to create the session with the accessory
+ *  @return             A SDLIAPSession object
  */
-@property (nullable, strong, nonatomic, readonly) EAAccessory *accessory;
+- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory forProtocol:(NSString *)protocol iAPSessionDelegate:(id<SDLIAPSessionDelegate>)iAPSessionDelegate;
+
+// document
+- (void) closeSession;
+
+// document
+- (void)write:(NSMutableData *) data length: (NSUInteger) length  withCompletionHandler:(void (^)(NSInteger bytesWritten))completionHandler;
 
 /**
- *  The session created between the app and the accessory.
+ *  The accessory with which to open a session.  Should be refactored to remove need to  make this public
  */
-@property (nullable, strong, nonatomic, readonly) EASession *eaSession;
+@property (nullable, strong, nonatomic, readonly) EAAccessory *accessory;
 
 /**
  *  The unique protocol string used to create the session with the accessory.
  */
 @property (nullable, strong, nonatomic, readonly) NSString *protocolString;
-
-/**
- *  Returns whether or not both the input and output streams for the session are closed.
- */
-@property (assign, readonly, getter=isStopped) BOOL stopped;
-
-/**
- * The input stream for the session is open when a `NSStreamEventOpenCompleted` event is received for the input stream. The input stream is closed when the stream status is `NSStreamStatusClosed`.
- */
-@property (nonatomic, assign) BOOL isInputStreamOpen;
-
-/**
- * The output stream for the session is open when a `NSStreamEventOpenCompleted` event is received for the output stream. The output stream has been closed when the stream status is `NSStreamStatusClosed`.
- */
-@property (nonatomic, assign) BOOL isOutputStreamOpen;
 
 /**
  *  The unique ID assigned to the session between the app and accessory. If no session exists the value will be 0.
@@ -51,51 +54,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic, readonly, getter=isSessionInProgress) BOOL sessionInProgress;
 
-/**
- *  Convenience initializer for setting an accessory and protocol string.
- *
- *  @param accessory    The accessory with which to open a session
- *  @param protocol     The unique protocol string used to create the session with the accessory
- *  @return             A SDLIAPSession object
- */
-- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory forProtocol:(NSString *)protocol;
-
-/**
- *  Starts a session.
- */
-- (void)startSession;
-
-/// Stops the current session.
-/// @param disconnectCompletionHandler Handler called when the session has been closed
-- (void)destroySessionWithCompletionHandler:(void (^)(void))disconnectCompletionHandler;
-
-/**
- *  Creates a session with the accessory.
- *
- *  @return Whether or not the session was created successfully
- */
-- (BOOL)createSession;
-
-/**
- *  Starts a session input or output stream.
- *
- *  @param stream The stream to be started.
- */
-- (void)startStream:(NSStream *)stream;
-
-/**
- *  Stops a session input or output stream.
- *
- *  @param stream The stream to be stopped.
- */
-- (void)stopStream:(NSStream *)stream;
-
-/**
- *  Cleans up a closed session
- */
-- (void)cleanupClosedSession;
+// document
+@property(readonly) BOOL hasSpaceAvailable;
+@property(readonly) BOOL bothStreamsOpen;
+@property(readonly) BOOL isConnected;
 
 
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLink/private/SDLIAPSession.m
+++ b/SmartDeviceLink/private/SDLIAPSession.m
@@ -11,9 +11,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SDLIAPSession ()
 
-@property (nullable, strong, nonatomic, readwrite) EASession *eaSession;
+@property (nonatomic, weak) id<SDLIAPSessionDelegate> iAPSessionDelegate;
 @property (nullable, strong, nonatomic, readwrite) EAAccessory *accessory;
+@property (nullable, strong, nonatomic, readwrite) EASession *eaSession;
+@property (copy, nonatomic) dispatch_queue_t iapSessionQueue;
 @property (nullable, strong, nonatomic, readwrite) NSString *protocolString;
+
+@property (nonatomic) BOOL inputStreamOpen;
+@property (nonatomic) BOOL outputStreamOpen;
+@property (nonatomic) BOOL runTheLoop;
 
 @end
 
@@ -21,91 +27,269 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Lifecycle
 
-- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory forProtocol:(NSString *)protocol {
+- (instancetype)initWithAccessory:(nullable EAAccessory *)accessory
+                      forProtocol:(NSString *)protocol
+               iAPSessionDelegate:(id<SDLIAPSessionDelegate>)iAPSessionDelegate {
     SDLLogD(@"SDLIAPSession init with accessory:%@ for protocol:%@", accessory.name, protocol);
-
     self = [super init];
     if (!self) { return nil; }
-
     _accessory = accessory;
+    _iAPSessionDelegate = iAPSessionDelegate;
+    _inputStreamOpen = NO;
+    _outputStreamOpen = NO;
     _protocolString = protocol;
-    _isInputStreamOpen = NO;
-    _isOutputStreamOpen = NO;
-
+    _runTheLoop = NO;
+    _iapSessionQueue = dispatch_queue_create("com.sdl.iapsession", DISPATCH_QUEUE_SERIAL);
+    [self startSession];
     return self;
 }
 
-#pragma mark - Abstract Methods
-
-- (void)startSession {}
-
-- (void)destroySessionWithCompletionHandler:(void (^)(void))disconnectCompletionHandler {}
-
-#pragma mark - Private Stream Lifecycle Helpers
-
-- (BOOL)createSession {
-    SDLLogD(@"Opening EASession with accessory: %@", self.accessory.name);
-    self.eaSession = [[EASession alloc] initWithAccessory:self.accessory forProtocol:self.protocolString];
-    return (self.eaSession != nil);
-}
-
-- (void)startStream:(NSStream *)stream {
-    stream.delegate = self;
-    [stream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-    [stream open];
-}
-
-- (void)stopStream:(NSStream *)stream {
-    // Verify stream is in a state that can be closed. Closing a stream that has not been opened has very bad effects.
-    NSUInteger status1 = stream.streamStatus;
-    if (status1 != NSStreamStatusNotOpen &&
-        status1 != NSStreamStatusClosed) {
-        [stream close];
-    } else if (status1 == NSStreamStatusNotOpen) {
-        // It's implicitly removed from the stream when it's closed, but not if it was never opened.
-        // When the USB cable is disconnected, the app will will call this method after the `NSStreamEventEndEncountered` event. The stream will already be in the closed state but it still needs to be removed from the run loop.
-        [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+- (void) dealloc {
+    if (self.eaSession != nil) {
+        [self closeSession];
     }
+}
 
+- (void)write:(NSMutableData *) data length: (NSUInteger) length  withCompletionHandler:(void (^)(NSInteger bytesWritten))completionHandler {
+    NSInteger bytesWritten = [self write:data.bytes maxLength: length];
+    completionHandler(bytesWritten);
+}
+
+- (NSInteger)write:(const uint8_t *)buffer maxLength:(NSUInteger)len {
+    return [self.eaSession.outputStream write:buffer maxLength:len];
+}
+
+#pragma mark - Private Stream Helpers
+
+- (void) startSession {
+    dispatch_async(self.iapSessionQueue, ^{
+        self.eaSession = [[EASession alloc] initWithAccessory:self.accessory forProtocol:self.protocolString];
+        SDLLogD(@"Created EASession with %@ Protocol and EASession is %@", self.protocolString, self.eaSession);
+        if (self.eaSession != nil) {
+            [self openStreams];
+            [self startStreamRunLoop];
+        } else {
+            SDLLogD(@"Failed to create EASession with Protocol : %@", self.protocolString);
+        }
+    });
+}
+
+- (void) openStreams {
+    if (self.eaSession != nil) {
+        [[self.eaSession inputStream] setDelegate: self];
+        [[self.eaSession inputStream] scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        [[self.eaSession inputStream] open];
+        [[self.eaSession outputStream] setDelegate: self];
+        [[self.eaSession outputStream] scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+        [[self.eaSession outputStream] open];
+    } else {
+        SDLLogD(@"EASession is nil when calling openStreams()");
+    }
+}
+
+- (void)close:(NSStream *)stream {
+    if (stream.streamStatus == NSStreamStatusClosed) {
+        if ([self isInputStream:stream]) {
+            SDLLogD(@"EASession inputstream already closed for EASession %@", self.eaSession);
+        }
+        if ([self isOutputStream:stream]) {
+            SDLLogD(@"EASession outputstream already closed for EASession %@", self.eaSession);
+        }
+        return;
+    }
+    
+    [stream close];
+    [stream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [stream setDelegate:nil];
+    
+    if ([self isInputStream:stream]) {
+        self.inputStreamOpen = NO;
+        SDLLogD(@"EASession closed input stream for EASession %@", self.eaSession);
+    }
+    if ([self isOutputStream:stream]) {
+        self.outputStreamOpen = NO;
+        SDLLogD(@"EASession closed output stream for EASession %@", self.eaSession);
+    }
+}
 
-    NSUInteger status2 = stream.streamStatus;
-    if (status2 == NSStreamStatusClosed) {
-        if (stream == [self.eaSession inputStream]) {
-            SDLLogD(@"Input stream closed");
-			self.isInputStreamOpen = NO;
-        } else if (stream == [self.eaSession outputStream]) {
-            SDLLogD(@"Output stream closed");
-			self.isOutputStreamOpen = NO;
+- (void) closeSession {
+    [self stopStreamRunLoop];
+    SDLLogD(@"Closing EASession streams");
+    if (self.eaSession != nil) {
+        [self close: self.eaSession.inputStream];
+        [self close: self.eaSession.outputStream];
+        self.eaSession = nil;
+    } else {
+        SDLLogD(@"Failed to close streams because EASession is already nil");
+    }
+}
+
+- (void) startStreamRunLoop {
+    self.runTheLoop = YES;
+    @autoreleasepool {
+        while(self.runTheLoop) {
+            [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.25f]];
         }
     }
 }
 
-- (void)cleanupClosedSession {
-    if (self.eaSession == nil) {
-        SDLLogD(@"Attempting to close session with accessory: %@, but it is already closed", self.accessory.name);
-        return;
-    }
+- (void) stopStreamRunLoop {
+    self.runTheLoop = NO;
+}
 
-    self.eaSession = nil;
-    SDLLogD(@"Session closed with: %@", self.accessory.name);
-    self.accessory.delegate = nil;
+#pragma mark - Delegate Stuff
+
+/**
+ *  Handles events on the input/output streams of the open session.
+ *
+ *  @param stream       The stream (either input or output) that the event occured on
+ *  @param eventCode    The stream event code
+ */
+- (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)eventCode {
+    switch (eventCode) {
+        case NSStreamEventOpenCompleted: {
+            [self streamDidOpen:stream];
+            break;
+        }
+        case NSStreamEventHasBytesAvailable: {
+            [self streamHasBytesAvailable:(NSInputStream *)stream];
+            break;
+        }
+        case NSStreamEventHasSpaceAvailable: {
+            [self streamHasSpaceToWrite];
+            break;
+        }
+        case NSStreamEventErrorOccurred: {
+            [self streamDidError:stream];
+            break;
+        }
+        case NSStreamEventEndEncountered: {
+            [self streamDidEnd:stream];
+            break;
+        }
+        case NSStreamEventNone:
+        default: {
+            break;
+        }
+    }
+}
+
+/**
+ *  Called when the session gets a `NSStreamEventOpenCompleted`. When both the input and output streams open, notify the lifecycle manager that a connection has been established with the accessory.
+ *
+ *  @param stream The stream that got the event code.
+ */
+- (void)streamDidOpen:(NSStream *)stream {
+    if ([self isInputStream:stream]) {
+        self.inputStreamOpen = YES;
+    }
+    if ([self isOutputStream: stream]) {
+        self.outputStreamOpen = YES;
+    }
+    if (self.bothStreamsOpen) {
+        SDLLogD(@"EASession input and output streams did open for protocol: %@ SDLIAPSession: %@", self.protocolString, self);
+        if (self.iAPSessionDelegate != nil) {
+            [self.iAPSessionDelegate streamsDidOpen];
+        }
+    }
+}
+
+/**
+ *  Called when the session gets a `NSStreamEventHasBytesAvailable` event code. The data is passed to the listener.
+ */
+- (void)streamHasBytesAvailable:(NSInputStream *)inputStream {
+    if (self.iAPSessionDelegate != nil) {
+        [self.iAPSessionDelegate streamHasBytesAvailable:inputStream];
+    }
+}
+
+/**
+ *  Called when the session gets a `NSStreamEventHasSpaceAvailable` event code. Send any queued data to Core.
+ */
+- (void)streamHasSpaceToWrite {
+    if (self.iAPSessionDelegate != nil) {
+        [self.iAPSessionDelegate streamHasSpaceToWrite];
+    }
+}
+
+/**
+ *  Called when the session gets a `NSStreamEventEndEncountered` event code. The current session is closed and a new session is attempted.
+ */
+- (void)streamDidEnd:(NSStream *)stream {
+    [self closeSession];
+    if (self.iAPSessionDelegate != nil) {
+        [self.iAPSessionDelegate streamsDidEnd];
+    }
+}
+
+/**
+ *  Called when the session gets a `NSStreamEventErrorOccurred` event code. The current session is closed and a new session is attempted.
+ */
+- (void)streamDidError:(NSStream *)stream {
+    if ([self isInputStream:stream]) {
+        SDLLogE(@"EASession input stream errored");
+    }
+    if ([self isOutputStream:stream]) {
+        SDLLogE(@"EASession output stream errored");
+    }
+    [self closeSession];
+    if (self.iAPSessionDelegate != nil) {
+        [self.iAPSessionDelegate streamDidError];
+    }
 }
 
 #pragma mark - Getters
 
-- (BOOL)isStopped {
-    return !self.isOutputStreamOpen && !self.isInputStreamOpen;
+- (BOOL)bothStreamsOpen {
+    if (self.inputStreamOpen && self.outputStreamOpen) {
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)bothStreamsClosed {
+    if (self.inputStreamOpen || self.outputStreamOpen) {
+        return NO;
+    }
+    return YES;
 }
 
 - (NSUInteger)connectionID {
     return self.eaSession.accessory.connectionID;
 }
 
+- (BOOL)hasSpaceAvailable {
+    return self.eaSession.outputStream.hasSpaceAvailable;
+}
+
+- (BOOL)isConnected {
+    return self.accessory.isConnected;
+}
+
+- (BOOL)isInputStream:(NSStream *)stream {
+    if (stream == self.eaSession.inputStream) {
+        return YES;
+    }
+    return NO;;
+}
+
+- (BOOL)isOutputStream:(NSStream *)stream {
+    if (stream == self.eaSession.outputStream) {
+        return YES;
+    }
+    return NO;;
+}
+
 - (BOOL)isSessionInProgress {
-    return !self.isStopped;
+    if (!self.inputStreamOpen && !self.outputStreamOpen) {
+        return NO;
+        SDLLogD(@"EASession not in progress");
+    }
+    return YES;
 }
 
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLink/private/SDLIAPTransport.m
+++ b/SmartDeviceLink/private/SDLIAPTransport.m
@@ -1,6 +1,5 @@
 //  SDLIAPTransport.h
 
-
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
@@ -55,6 +54,16 @@ int const CreateSessionRetries = 3;
     // Wait for setup to complete before scanning for accessories
 
     return self;
+}
+
+- (void) dealloc {
+    SDLLogV(@"SDLIAPTransport dealloc executed");
+    if (self.dataSession != nil) {
+        [self.dataSession closeSession];
+    }
+    if (self.controlSession != nil) {
+        [self.controlSession closeSession];
+    }
 }
 
 #pragma mark - Notifications
@@ -141,37 +150,36 @@ int const CreateSessionRetries = 3;
 
     if (!self.controlSession.isSessionInProgress && !self.dataSession.isSessionInProgress) {
         SDLLogV(@"Accessory (%@, %@), disconnected, but no session is in progress.", accessory.name, accessory.serialNumber);
-        [self sdl_closeSessions];
+        [self sdl_destroySessions];
     } else if (self.dataSession.isSessionInProgress) {
-        if (self.dataSession.connectionID != accessory.connectionID) {
-            SDLLogD(@"Accessory's connectionID, %lu, does not match the connectionID of the current data session, %lu. Another phone disconnected from the head unit. The session will not be closed.", accessory.connectionID, self.dataSession.connectionID);
-            return;
+        if (self.dataSession.connectionID == accessory.connectionID) {
+            // The data session has been established. Tell the delegate that the transport has disconnected. The lifecycle manager will destroy and create a new transport object.
+            SDLLogV(@"Accessory (%@, %@) disconnected during a data session", accessory.name, accessory.serialNumber);
+            [self sdl_destroyTransport];
+        } else {
+            SDLLogD(@"Accessory connectionID, %lu, does not match the connectionID of the current data session, %lu. Another phone disconnected from the head unit. The session will not be closed.", accessory.connectionID, self.dataSession.connectionID);
         }
-        // The data session has been established. Tell the delegate that the transport has disconnected. The lifecycle manager will destroy and create a new transport object.
-        SDLLogV(@"Accessory (%@, %@) disconnected during a data session", accessory.name, accessory.serialNumber);
-        [self sdl_destroyTransport];
     } else if (self.controlSession.isSessionInProgress) {
-        if (self.controlSession.connectionID != accessory.connectionID) {
+        if (self.controlSession.connectionID == accessory.connectionID) {
+            // The data session has yet to be established so the transport has not yet connected. DO NOT unregister for notifications from the accessory.
+            SDLLogV(@"Accessory (%@, %@) disconnected during a control session", accessory.name, accessory.serialNumber);
+            [self sdl_destroySessions];
+        } else {
             SDLLogD(@"Accessory's connectionID, %lu, does not match the connectionID of the current control session, %lu. Another phone disconnected from the head unit. The session will not be closed.", accessory.connectionID, self.controlSession.connectionID);
-            return;
         }
-        // The data session has yet to be established so the transport has not yet connected. DO NOT unregister for notifications from the accessory.
-        SDLLogV(@"Accessory (%@, %@) disconnected during a control session", accessory.name, accessory.serialNumber);
-        [self sdl_closeSessions];
     } else {
         SDLLogV(@"Accessory (%@, %@) disconnecting during an unknown session", accessory.name, accessory.serialNumber);
-        [self sdl_closeSessions];
+        [self sdl_destroySessions];
     }
 }
 
 /**
- *  Closes and cleans up the sessions after a control session has been closed. Since a data session has not been established, the lifecycle manager has not transitioned to state started. Do not unregister for notifications from accessory connections/disconnections otherwise the library will not be able to connect to an accessory again.
+ *  Destroys and cleans up the sessions after a control session has been closed. Since a data session has not been established, the lifecycle manager has not transitioned to state started. Do not unregister for notifications from accessory connections/disconnections otherwise the library will not be able to connect to an accessory again.
  */
-- (void)sdl_closeSessions {
+- (void)sdl_destroySessions {
     self.retryCounter = 0;
     self.sessionSetupInProgress = NO;
-
-    [self sdl_closeSessionsWithCompletionHandler:nil];
+    [self sdl_closeSessions:nil];
 }
 
 /**
@@ -224,9 +232,18 @@ int const CreateSessionRetries = 3;
     self.sessionSetupInProgress = NO;
     self.transportDestroyed = YES;
 
-    [self sdl_closeSessionsWithCompletionHandler:disconnectCompletionHandler];
+    [self sdl_closeSessions:disconnectCompletionHandler];
 }
 
+- (EAAccessory * _Nullable)accessory {
+    if (self.controlSession.accessory != nil) {
+        return self.controlSession.accessory;
+    }
+    if (self.dataSession.accessory != nil) {
+        return self.dataSession.accessory;
+    }
+    return nil;
+}
 
 #pragma mark Helpers
 
@@ -290,7 +307,7 @@ int const CreateSessionRetries = 3;
     self.sessionSetupInProgress = NO;
 
     __weak typeof(self) weakSelf = self;
-    [self sdl_closeSessionsWithCompletionHandler:^{
+    [self sdl_closeSessions:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         // Search connected accessories
         [strongSelf sdl_connect:nil];
@@ -298,34 +315,31 @@ int const CreateSessionRetries = 3;
 }
 
 /// Helper method for closing both the data and control sessions.
-/// @param disconnectCompletionHandler Handler called when both the data and control sessions have been disconnected successfully
-- (void)sdl_closeSessionsWithCompletionHandler:(nullable void (^)(void))disconnectCompletionHandler {
+/// @param completionHandler Handler called when both the data and control sessions have been disconnected successfully
+- (void)sdl_closeSessions:(nullable void (^)(void))completionHandler {
     dispatch_group_t endSessionsTask = dispatch_group_create();
+    
     dispatch_group_enter(endSessionsTask);
-
     if (self.controlSession != nil) {
         dispatch_group_enter(endSessionsTask);
-        [self.controlSession destroySessionWithCompletionHandler:^{
-            SDLLogV(@"Control session destroyed");
-            dispatch_group_leave(endSessionsTask);
-        }];
+        [self.controlSession closeSession];
+        self.controlSession = nil;
+        SDLLogV(@"Control session tear down complete");
+        dispatch_group_leave(endSessionsTask);
     }
-
     if (self.dataSession != nil) {
         dispatch_group_enter(endSessionsTask);
-        [self.dataSession destroySessionWithCompletionHandler:^{
-            SDLLogV(@"Data session destroyed");
-            dispatch_group_leave(endSessionsTask);
-        }];
+        [self.dataSession closeSession];
+        self.dataSession = nil;
+        SDLLogV(@"Data session tear down complete");
+        dispatch_group_leave(endSessionsTask);
     }
-
     dispatch_group_leave(endSessionsTask);
-
-    // This will always run after all `leave` calls
+    
     dispatch_group_notify(endSessionsTask, [SDLGlobals sharedGlobals].sdlProcessingQueue, ^{
         SDLLogV(@"Both the data and control sessions are closed");
-        if (disconnectCompletionHandler != nil) {
-            disconnectCompletionHandler();
+        if (completionHandler != nil) {
+            completionHandler();
         }
     });
 }
@@ -338,7 +352,7 @@ int const CreateSessionRetries = 3;
 /**
  *  Called when the control session should be retried.
  */
-- (void)controlSessionShouldRetry {
+- (void)controlSessionDidEnd {
     SDLLogV(@"Retrying the control session");
     [self sdl_retryEstablishSession];
 }
@@ -351,8 +365,10 @@ int const CreateSessionRetries = 3;
  */
 - (void)controlSession:(nonnull SDLIAPControlSession *)controlSession didReceiveProtocolString:(nonnull NSString *)protocolString {
     SDLLogD(@"Control transport session received data session number: %@", protocolString);
-    self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:controlSession.accessory delegate:self forProtocol:protocolString];
-    [self.dataSession startSession];
+    EAAccessory *accessory =  self.controlSession.accessory;
+    [self.controlSession closeSession];
+    self.controlSession = nil;
+    self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
 }
 
 
@@ -370,7 +386,7 @@ int const CreateSessionRetries = 3;
 /**
  *  Called when the data session should be retried.
  */
-- (void)dataSessionShouldRetry {
+- (void) dataSessionDidEnd{
     SDLLogV(@"Retrying the data session");
     [self sdl_retryEstablishSession];
 }
@@ -539,18 +555,21 @@ int const CreateSessionRetries = 3;
     if (![self.class sdl_plistContainsAllSupportedProtocolStrings]) {
         return NO;
     }
-
+    
     if ([protocolString isEqualToString:MultiSessionProtocolString] && SDL_SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9")) {
+        if (self.dataSession != nil) {
+            [self.dataSession closeSession];
+        }
         self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
-        [self.dataSession startSession];
         return YES;
     } else if ([protocolString isEqualToString:ControlProtocolString]) {
-        self.controlSession = [[SDLIAPControlSession alloc] initWithAccessory:accessory delegate:self];
-        [self.controlSession startSession];
+        if (self.controlSession != nil) {
+            [self.controlSession closeSession];
+        }
+        self.controlSession = [[SDLIAPControlSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
         return YES;
     } else if ([protocolString isEqualToString:LegacyProtocolString]) {
         self.dataSession = [[SDLIAPDataSession alloc] initWithAccessory:accessory delegate:self forProtocol:protocolString];
-        [self.dataSession startSession];
         return YES;
     }
 
@@ -560,3 +579,5 @@ int const CreateSessionRetries = 3;
 @end
 
 NS_ASSUME_NONNULL_END
+
+

--- a/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPControlSessionSpec.m
+++ b/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPControlSessionSpec.m
@@ -12,7 +12,7 @@
 
 #import "SDLIAPControlSession.h"
 
-#import "EAAccessory+OCMock.h"
+#import "EAAccessory+OCMock.m"
 #import "SDLIAPConstants.h"
 #import "SDLIAPControlSessionDelegate.h"
 #import "SDLIAPSession.h"
@@ -38,29 +38,16 @@ describe(@"SDLIAPControlSession", ^{
 
     describe(@"init", ^{
         beforeEach(^{
-            controlSession = [[SDLIAPControlSession alloc] initWithAccessory:mockAccessory delegate:mockDelegate];
+            controlSession = [[SDLIAPControlSession alloc]          initWithAccessory:mockAccessory delegate:mockDelegate forProtocol:ControlProtocolString];
         });
-
-        it(@"Should get/set correctly", ^{
+        
+        it(@"Should init correctly", ^{
             expect(controlSession.accessory).to(equal(mockAccessory));
-            expect(controlSession.protocolString).to(equal(ControlProtocolString));
-            expect(controlSession.protocolIndexTimer).to(beNil());
             expect(controlSession.delegate).to(equal(mockDelegate));
+            expect(controlSession.isSessionInProgress).to(beFalse());
         });
     });
 
-    describe(@"starting a session", ^{
-        context(@"it should attempt to retry the session", ^{
-            beforeEach(^{
-                controlSession = [[SDLIAPControlSession alloc] initWithAccessory:nil delegate:mockDelegate];
-            });
-
-            it(@"Should start correctly", ^{
-                [controlSession startSession];
-                OCMExpect([mockDelegate controlSessionShouldRetry]);
-            });
-        });
-    });
 });
 
 QuickSpecEnd

--- a/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPDataSessionSpec.m
+++ b/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPDataSessionSpec.m
@@ -12,7 +12,7 @@
 
 #import "SDLIAPDataSession.h"
 
-#import "EAAccessory+OCMock.h"
+#import "EAAccessory+OCMock.m"
 #import "SDLIAPConstants.h"
 #import "SDLIAPSession.h"
 #import "SDLIAPDataSessionDelegate.h"
@@ -44,33 +44,16 @@ describe(@"SDLIAPDataSession", ^{
         });
 
         it(@"Should init correctly", ^{
-            expect(dataSession.delegate).to(equal(mockDelegate));
-            expect(dataSession.sendDataQueue).toNot(beNil());
-        });
-
-        it(@"Should get correctly", ^{
             expect(dataSession.accessory).to(equal(mockAccessory));
-            expect(dataSession.protocolString).to(equal(MultiSessionProtocolString));
-            expect(dataSession.isStopped).to(beTrue());
-            expect(dataSession.connectionID).to(equal(0));
-            expect(dataSession.sessionInProgress).to(beFalse());
+            expect(dataSession.delegate).to(equal(mockDelegate));
+            expect(dataSession.isSessionInProgress).to(beFalse());
+
         });
     });
 
-    describe(@"starting a session", ^{
-        context(@"it should attempt to retry the session", ^{
-            beforeEach(^{
-                dataSession = [[SDLIAPDataSession alloc] initWithAccessory:nil delegate:mockDelegate forProtocol:MultiSessionProtocolString];
-            });
-
-            it(@"Should start correctly", ^{
-                [dataSession startSession];
-                OCMExpect([mockDelegate dataSessionShouldRetry]);
-            });
-        });
-    });
 });
 
 QuickSpecEnd
+
 
 

--- a/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPSessionSpec.m
+++ b/SmartDeviceLinkTests/TransportSpecs/iAP/SDLIAPSessionSpec.m
@@ -10,38 +10,35 @@
 #import <Nimble/Nimble.h>
 #import <OCMock/OCMock.h>
 
-#import "EAAccessory+OCMock.h"
+#import "EAAccessory+OCMock.m"
 #import "SDLIAPSession.h"
 #import "SDLIAPConstants.h"
-
 
 QuickSpecBegin(SDLIAPSessionSpec)
 
 describe(@"SDLIAPSession", ^{
     __block EAAccessory *mockAccessory = nil;
+    __block id<SDLIAPSessionDelegate> mockDelegate = nil;
 
     describe(@"Initialization", ^{
         __block SDLIAPSession *testSession = nil;
 
         beforeEach(^{
             mockAccessory = [EAAccessory.class sdlCoreMock];
-            testSession = [[SDLIAPSession alloc] initWithAccessory:mockAccessory forProtocol:ControlProtocolString];
+            mockDelegate = OCMProtocolMock(@protocol(SDLIAPSessionDelegate));
+            testSession = [[SDLIAPSession alloc] initWithAccessory:mockAccessory forProtocol:ControlProtocolString iAPSessionDelegate:mockDelegate];
         });
 
         it(@"should init correctly", ^{
             expect(testSession.accessory).to(equal(mockAccessory));
             expect(testSession.protocolString).to(equal(ControlProtocolString));
-            expect(testSession.isInputStreamOpen).to(beFalse());
-            expect(testSession.isOutputStreamOpen).to(beFalse());
-        });
-
-        it(@"should get correctly", ^{
-            expect(testSession.isStopped).to(beTrue());
-            expect(testSession.connectionID).to(equal(0));
+            expect(testSession.bothStreamsOpen).to(beFalse());
+            expect(testSession.hasSpaceAvailable).to(beFalse());
             expect(testSession.isSessionInProgress).to(beFalse());
         });
     });
 });
 
 QuickSpecEnd
+
 


### PR DESCRIPTION
Fixes #1799  (when used in conjunction with https://github.com/kmicha19-ford/sdl_ios/pull/2)
Fixes #1809
Fixes #1892
Fixes #1893

This PR is ready for review.

### Risk

This PR makes no  API changes.

### Testing Plan

- I have verified that I have not introduced new warnings in this PR (or explain why below)
- I have tested this PR against Core and verified behavior.

#### Unit Tests

Unit tests were updated for the refactored classes.

#### Core Tests

- Built the Obj-C example app and verified that all interactions work
   - iAP disconnect / reconnect
   - LockScreen on/off rapidly
- Built the Swift example app and verified that all interactions work
   - iAP disconnect / reconnect
   - LockScreen on/off rapidly

### Summary

* Refactors iAPSession code that uses the Apple External Accessory Frameworks to create, open, use, and close EASessions. 

### Changelog

##### Breaking Changes
* None

##### Enhancements

* Moves all managment of EASession creation, open, and closing into a single class, SDLIAPSession
* Eliminates the use of NSThread from SDLIAPDataSession
* SDLIAPSession now uses a DispatchQueue to provide the required thread for EASession
* Uses composition instead of inheritance, SDLIAPControlSession and SDLIAPDataSession now use SDLIAPSession instead of being subclasses of it
* Provides a short simple code path for closing EASessions
* Eliminates over two hundred lines of code

### Tasks Remaining:
- More unit tests

### CLA
- I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
